### PR TITLE
arvojoukko --> maalijoukko

### DIFF
--- a/MAA1/chapters/funktio.tex
+++ b/MAA1/chapters/funktio.tex
@@ -30,7 +30,7 @@ $f(\text{särkylääke}) = 9$ ja $f(\text{televisio}) = 23$.
 Funktioiden käyttämiseen liittyy joitakin vakiintuneita tapoja:
 \begin{itemize}
 \item $f(x) = y$ lausutaan: ''Funktio saa arvon $y$ pisteessä $x$'',
-\item Funktion määrittely- ja arvojoukko jätetään usein merkitsemättä, jos ne voidaan päätellä asiayhteydestä. Tällä kurssilla arvojoukkona on yleensä reaaliluvut.
+\item Funktion määrittely- ja maalijoukko jätetään usein merkitsemättä, jos ne voidaan päätellä asiayhteydestä. Tällä kurssilla maalijoukkona on yleensä reaaliluvut.
 \item Toisinaan funktiolle ja funktion kuvaajalle ei tehdä selkeää eroa:
 $y = f(x)$ samaistetaan koordinaatistoon piirretyn funktion kuvaajan kanssa.
 Periaatteessa funktio ja sen kuvaaja ovat kuitenkin eri asioita.


### PR DESCRIPTION
Ajatusvirhe korjattu: Funktio-kappaleessa oli kahdessa kohtaa sana arvojoukko sanan maalijoukko sijaan. Vaihdoin maalijoukoksi.

t. Samuli
